### PR TITLE
add test case converting relation to_a does not raise an error

### DIFF
--- a/spec/activerecord/safe_query_spec.rb
+++ b/spec/activerecord/safe_query_spec.rb
@@ -16,4 +16,8 @@ RSpec.describe ActiveRecord::Relation::SafeQuery do
   it "does not raise an error when iterating over a relation with an in clause and a limit" do
     expect { User.where(id: [1, 2, 3]).limit(1).each {} }.to_not raise_error
   end
+
+  it "does not raise an error when iterating over a relation converted to an array" do
+    expect { User.all.to_a.each {} }.to_not raise_error
+  end
 end


### PR DESCRIPTION
Reference #1
This PR adds a test covering the case where converting the relation to an array with `to_a` does not raise an error.